### PR TITLE
ignore newlines for search

### DIFF
--- a/app.py
+++ b/app.py
@@ -121,7 +121,7 @@ def find_font():
 
 def normalize_string(s):
     return ''.join(
-        c for c in unicodedata.normalize('NFD', s)
+        c for c in unicodedata.normalize('NFD', s.replace('\\n', ' '))
         if unicodedata.category(c) != 'Mn'
     )
 


### PR DESCRIPTION
When searching for a phrase that is split over multiple lines using a \N, the results would not be displayed. This PR fixes that 😃 