### PR TITLE
fix: locating a subtitle does not highlight it

### DIFF
--- a/subclipper/app/routes.py
+++ b/subclipper/app/routes.py
@@ -1,3 +1,4 @@
+import json
 from flask import Response, Blueprint, render_template, request, send_file, send_from_directory, make_response, jsonify, current_app
 from pathlib import Path
 import logging
@@ -84,7 +85,8 @@ def locate(video_id: str, sub_id: str):
         return f"no subtitle with id {sub_id} from video with id {video_id} found", 404
     
     resp = flask.Response("OK")
-    resp.headers['HX-Redirect'] = f"/?page={sub_page[0]}&page_length={page_length}#{video_id}-{sub_id}"
+    fragment_path = f"/?page={sub_page[0]}&page_length={page_length}#e{video_id}-s{sub_id}"
+    resp.headers['HX-Location'] = json.dumps({"path": fragment_path, "target": "main"})
     resp.status_code = 200
 
     return resp

--- a/subclipper/app/templates/subtitles.html
+++ b/subclipper/app/templates/subtitles.html
@@ -14,7 +14,7 @@
             <ul class="list bg-base-100 rounded-box shadow-md">
                 {% for sub in subs %}
                     <li
-                        id="{{ sub.video_id }}-{{ sub.id }}"
+                        id="e{{ sub.video_id }}-s{{ sub.id }}"
                         class="list-row hover:bg-base-200 cursor-pointer transition-colors target:bg-primary target:hover:bg-primary/50"
                         hx-get="/sub_form/{{ sub['video_id'] }}/{{ sub['id'] }}"
                         hx-replace-url="true"
@@ -32,7 +32,7 @@
                                     hx-replace-url="true"
                                     class="text-xs uppercase italic opacity-60 color-info hover:underline"
                                 >
-                                    #{{ sub.video_id }}-{{ sub.id }}
+                                    #e{{ sub.video_id }}-s{{ sub.id }}
                                 </a>
                             </div>
                             <div>{{ sub.text }}</div>

--- a/subclipper/scripts/main.ts
+++ b/subclipper/scripts/main.ts
@@ -1,4 +1,5 @@
 export * from "./components/dual-handle-slider";
+import { SwapOptions } from "htmx.org";
 import "./main.css"
 
 let htmx: typeof import("htmx.org").default;
@@ -62,21 +63,14 @@ async function main() {
     },
   })
 
-  htmx.defineExtension(`copy-to-clipboard`, {
-    onEvent: (name, event) => {
-        if(name === `htmx:beforeSwap`) {
-            const response = event.detail.xhr.response
-            const blob = new Blob([response], { type: `image/gif` })
-            navigator.clipboard.write([
-                new ClipboardItem({
-                    [blob.type]: blob
-                })
-            ])
-        }
-        return true
+  // HTMX uses history.pushState, which does not update CSS :target pseudoclass: https://developer.mozilla.org/en-US/docs/Web/CSS/:target#description
+  // Fix taken and modified from https://github.com/bigskysoftware/htmx/issues/3447
+  htmx.on(`htmx:afterSwap`, (event: Event & { detail: SwapOptions["eventInfo"] }) => {
+    const hashFragment = event.detail.pathInfo.requestPath.split(`#`).at(1)
+    if(hashFragment !== undefined && hashFragment !== ``) {
+      window.location.hash = hashFragment;
     }
   })
-
 
   htmx.process(document.body)
 }


### PR DESCRIPTION
There were two problems:
- An element's ID cannot start with a number
- HTMX uses `history.pushState`, [a method that does not trigger CSS to add the `:target` pseudoclass](https://developer.mozilla.org/en-US/docs/Web/CSS/:target#description)