### PR TITLE
Usability fixes: search/page persistence, dropdown race, pagination, download button

### DIFF
--- a/src/app/routes.py
+++ b/src/app/routes.py
@@ -19,6 +19,7 @@ from jinja2 import Template
 from ..core.models import ClipSettings, VideoScanStatus, Video, Subtitle
 from ..utils.config import Config
 from ..utils.rate_limit import RateLimiter
+from ..utils.pagination import paginate_window
 from sub2clip.subtitles import Subtitle as SSubtitle
 
 logger = logging.getLogger(__name__)
@@ -247,10 +248,9 @@ def scan(path: str):
     config.subtitle_indexer.scan(Path(path))
     return "OK"
 
-@bp.route("/video_selection_dropdown", defaults={'path': '.'})
-@bp.route("/video_selection_dropdown/", defaults={'path': '.'})
-@bp.route("/video_selection_dropdown/<path:path>")
-def current_path(path):
+@bp.route("/video_selection_dropdown")
+def current_path():
+    path = request.args.get('path', '.', type=str) or '.'
     if path == "." and config.single_show_name is None:
         # We do not want to show it on the homescreen
         return ""
@@ -456,6 +456,7 @@ def index(path: str):
             page=page,
             page_length=page_length,
             pages=pages,
+            page_numbers=paginate_window(page, pages),
         )
         resp.headers['HX-Trigger-After-Settle'] = 'refetch-current-path'
 

--- a/src/app/routes.py
+++ b/src/app/routes.py
@@ -385,7 +385,7 @@ def get_gif_view():
         resp.headers['HX-Reswap'] = 'outerHTML'
         return resp, 400
 
-    return cached_render_template("gif_view.html", url=f"/gif?{request.query_string.decode()}")
+    return cached_render_template("gif_view.html", url=f"/gif?{request.query_string.decode()}", format=settings.format)
 
 @bp.route("/gif")
 def get_gif():

--- a/src/app/routes.py
+++ b/src/app/routes.py
@@ -37,9 +37,19 @@ _gif_rate_limiter = RateLimiter(
 ) if _gif_rate_limit_per_minute > 0 else None
 
 def cached_render_template(template, **context):
-    """Render a template with caching headers."""
+    """Render a template, explicitly preventing the response from being cached.
+
+    Several routes (e.g. "/") serve completely different content for the same URL
+    depending on the HX-Request header (a full page vs. just the fragment htmx asked
+    for), and never set a Vary/Cache-Control header to say so - which previously let
+    browsers reuse a cached fragment response for a later plain navigation to the same
+    URL, blanking out everything outside <main>. No response rendered through here is
+    meant to be cached at all, so rule it out entirely rather than rely on Vary.
+    """
     rendered_template = render_template(template, **context)
     response = make_response(rendered_template)
+    response.headers['Cache-Control'] = 'no-store'
+    response.headers['Vary'] = 'HX-Request'
     return response
 
 class SseEvent(NamedTuple):

--- a/src/app/routes.py
+++ b/src/app/routes.py
@@ -261,8 +261,13 @@ def scan(path: str):
 @bp.route("/video_selection_dropdown")
 def current_path():
     path = request.args.get('path', '.', type=str) or '.'
-    if path == "." and config.single_show_name is None:
-        # We do not want to show it on the homescreen
+    filter = request.args.get('filter', '', type=str)
+    page = request.args.get('page', None, type=int)
+    if path == "." and filter == '' and page is None and config.single_show_name is None:
+        # Mirrors index()'s own check for the bare landing page: that page already has its
+        # own full folder browser, so the "currently searching" widget would be redundant.
+        # Once there's an active search or page (still at path=".", since a homepage search
+        # doesn't change window.location.pathname), it belongs back in the subtitle list view.
         return ""
     else:
         return cached_render_template(

--- a/src/app/templates/filesystem_list_item.html
+++ b/src/app/templates/filesystem_list_item.html
@@ -35,7 +35,7 @@
             hx-push-url="false"
             hx-get="/scan_status/{{ relative_path }}"
             {% if open_by_default or is_root_child %}
-            hx-trigger="load"
+            hx-trigger="load[!window.htmxRestoringHistory()]"
             {% else %}
             hx-trigger="click once from:#id-{{ encode_id(relative_path.parent.__str__()) }}"
             {% endif %}
@@ -77,7 +77,7 @@
                     sse-swap="{{ relative_path }}"
                     hx-get="/scan_status/{{ relative_path }}"
                     {% if open_by_default or is_root_child %}
-                    hx-trigger="load"
+                    hx-trigger="load[!window.htmxRestoringHistory()]"
                     {% else %}
                     hx-trigger="click once from:#id-{{ encode_id(relative_path.parent.__str__()) }}"
                     {% endif %}

--- a/src/app/templates/filesystem_list_item.html
+++ b/src/app/templates/filesystem_list_item.html
@@ -4,7 +4,7 @@
 {% set open_by_default = is_root %}
 <li
     id="id-{{ encode_id(relative_path.__str__()) }}"
-    class="h-full overflow-auto"
+    class="{{ 'h-full' if is_root else '' }}"
     name="video"
     value=""
     {% if is_root %}

--- a/src/app/templates/gif_view.html
+++ b/src/app/templates/gif_view.html
@@ -12,4 +12,14 @@
         src="{{ url }}"
         alt="The clip is loading..."
     />
+    <a
+        href="{{ url }}"
+        download="clip.{{ format }}"
+        hx-boost="false"
+        class="btn btn-circle btn-sm absolute bottom-2 right-2 z-20"
+        title="Download clip"
+        aria-label="Download clip"
+    >
+        {% include "icons/arrow-down-tray.html" %}
+    </a>
 {% endif %}

--- a/src/app/templates/icons/arrow-down-tray.html
+++ b/src/app/templates/icons/arrow-down-tray.html
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
+</svg>

--- a/src/app/templates/index.html
+++ b/src/app/templates/index.html
@@ -10,7 +10,7 @@
         <ul
             class="w-full h-full menu menu-vertical flex-nowrap"
             hx-get="/files"
-            hx-trigger="load"
+            hx-trigger="load[!window.htmxRestoringHistory()]"
         >
             <div class="flex flex-col gap-2 overflow-hidden">
                 <div class="skeleton w-full h-12"></div>

--- a/src/app/templates/root.html
+++ b/src/app/templates/root.html
@@ -70,21 +70,19 @@
             <div class="w-full flex-initial md:flex-1 flex flex-row justify-around md:px-4">
                 <div
                     class="flex-auto flex justify-center"
-                    hx-get="/video_selection_dropdown/*"
+                    hx-get="/video_selection_dropdown"
                     hx-trigger="load, refetch-current-path from:body"
-                    hx-ext="interpolate-current-path"
+                    hx-vals='js:{path: window.location.pathname === "/" ? "." : window.location.pathname.slice(1)}'
                 >
-                    
+
                 </div>
             </div>
         </div>
     </header>
     <main
         class="flex-1 min-h-0 md:p-8"
-        hx-ext="preserve-params"
-        hx-get="/{{ path }}"
+        hx-get="/{{ path }}{% if request.query_string %}?{{ request.query_string.decode() }}{% endif %}"
         hx-trigger="load"
-        {# hx-include="[name='filter']" #}
     >
         <div class="skeleton w-full h-full bg-base-200"></div>
     </main>

--- a/src/app/templates/root.html
+++ b/src/app/templates/root.html
@@ -72,7 +72,11 @@
                     class="flex-auto flex justify-center"
                     hx-get="/video_selection_dropdown"
                     hx-trigger="load[!window.htmxRestoringHistory()], refetch-current-path from:body"
-                    hx-vals='js:{path: window.location.pathname === "/" ? "." : window.location.pathname.slice(1)}'
+                    hx-vals='js:{
+                        path: window.location.pathname === "/" ? "." : decodeURIComponent(window.location.pathname.slice(1)),
+                        filter: new URLSearchParams(window.location.search).get("filter") || "",
+                        page: new URLSearchParams(window.location.search).get("page") || ""
+                    }'
                 >
 
                 </div>

--- a/src/app/templates/root.html
+++ b/src/app/templates/root.html
@@ -71,7 +71,7 @@
                 <div
                     class="flex-auto flex justify-center"
                     hx-get="/video_selection_dropdown"
-                    hx-trigger="load, refetch-current-path from:body"
+                    hx-trigger="load[!window.htmxRestoringHistory()], refetch-current-path from:body"
                     hx-vals='js:{path: window.location.pathname === "/" ? "." : window.location.pathname.slice(1)}'
                 >
 
@@ -82,7 +82,7 @@
     <main
         class="flex-1 min-h-0 md:p-8"
         hx-get="/{{ path }}{% if request.query_string %}?{{ request.query_string.decode() }}{% endif %}"
-        hx-trigger="load"
+        hx-trigger="load[!window.htmxRestoringHistory()]"
     >
         <div class="skeleton w-full h-full bg-base-200"></div>
     </main>

--- a/src/app/templates/subtitles.html
+++ b/src/app/templates/subtitles.html
@@ -63,7 +63,7 @@
                 <span class="join-item btn btn-disabled">…</span>
             {% else %}
                 <button
-                    class="join-item btn {{ 'btn-active' if i == page else '' }}"
+                    class="join-item btn {{ 'btn-primary' if i == page else '' }}"
                     hx-get="/?page={{ i }}"
                     hx-target="main"
                     hx-replace-url="true"

--- a/src/app/templates/subtitles.html
+++ b/src/app/templates/subtitles.html
@@ -57,14 +57,14 @@
             </ul>
         {% endif %}
     </div>
-    <div class="flex-none join flex flex-row justify-safe-center min-h-12 overflow-x-auto">
+    <div class="flex-none join flex flex-row justify-center-safe min-h-12 overflow-x-auto">
         {% for i in page_numbers %}
             {% if i is none %}
                 <span class="join-item btn btn-disabled">…</span>
             {% else %}
                 <button
                     class="join-item btn {{ 'btn-primary' if i == page else '' }}"
-                    hx-get="/?page={{ i }}"
+                    hx-get="/{{ path }}?page={{ i }}"
                     hx-target="main"
                     hx-replace-url="true"
                     hx-ext="preserve-params"

--- a/src/app/templates/subtitles.html
+++ b/src/app/templates/subtitles.html
@@ -29,8 +29,8 @@
                                 height="50"
                                 loading="lazy"
                                 decoding="async"
-                                onload="this.classList.remove('opacity-0'); this.previousElementSibling.remove()"
-                                onerror="this.previousElementSibling.classList.add('bg-error/20')"
+                                onload="this.classList.remove('opacity-0'); this.previousElementSibling?.remove()"
+                                onerror="this.previousElementSibling?.classList.add('bg-error/20')"
                             />
                         </div>
                         {% endif %}
@@ -58,16 +58,20 @@
         {% endif %}
     </div>
     <div class="flex-none join flex flex-row justify-safe-center min-h-12 overflow-x-auto">
-        {% for i in range(0, pages) %}
-            <button
-                class="join-item btn {{ 'btn-active' if i == page else '' }}"
-                hx-get="/?page={{ i }}"
-                hx-target="main"
-                hx-replace-url="true"
-                hx-ext="preserve-params"
-            >
-                {{ i+1 }}
-            </button>
+        {% for i in page_numbers %}
+            {% if i is none %}
+                <span class="join-item btn btn-disabled">…</span>
+            {% else %}
+                <button
+                    class="join-item btn {{ 'btn-active' if i == page else '' }}"
+                    hx-get="/?page={{ i }}"
+                    hx-target="main"
+                    hx-replace-url="true"
+                    hx-ext="preserve-params"
+                >
+                    {{ i+1 }}
+                </button>
+            {% endif %}
         {% endfor %}
     </div>
     </div>

--- a/src/app/templates/video_selection_dropdown.html
+++ b/src/app/templates/video_selection_dropdown.html
@@ -10,7 +10,7 @@
         tabindex="1"
         class="w-full dropdown-content menu overflow-auto max-h-180 bg-base-100 rounded-box z-1 p-2 shadow-sm"
         hx-get="/files"
-        hx-trigger="load"
+        hx-trigger="load[!window.htmxRestoringHistory()]"
     >
         <div class="skeleton bg-base-200 h-4 w-28"></div>
         <div class="skeleton bg-base-200 h-4 w-full"></div>

--- a/src/scripts/main.ts
+++ b/src/scripts/main.ts
@@ -4,6 +4,25 @@ export * from "./components/closable-dialog"
 import { SwapOptions } from "htmx.org";
 import "./main.css"
 
+// Restoring a page from htmx's history cache (back/forward) replaces document.body's
+// innerHTML wholesale with the cached snapshot, then reprocesses it. Every element in
+// that snapshot with hx-trigger="load" - <main>, the video selection dropdown, the file
+// browser list, etc. - looks "new" to htmx post-swap and fires again, even though the
+// snapshot already has settled, correct content. That redundantly re-fetches everything
+// and, worse, opens a fresh SSE connection per re-fetch without closing the old one.
+// hx-trigger="load[!window.htmxRestoringHistory()]" on those elements uses this flag to
+// skip that redundant refire specifically during a history restore.
+//
+// This is set up here, at module top-level, rather than inside main() below: htmx's own
+// ESM build auto-processes the document on DOMContentLoaded independently of (and
+// sometimes before) this module's own async setup finishes, so hx-trigger conditions can
+// already be evaluated before main() would otherwise get around to defining this. Plain
+// addEventListener (rather than htmx.on) avoids even depending on htmx having loaded yet.
+let restoringHistory = false;
+(window as any).htmxRestoringHistory = () => restoringHistory;
+document.body.addEventListener(`htmx:historyCacheHit`, () => { restoringHistory = true; })
+document.body.addEventListener(`htmx:historyRestore`, () => { restoringHistory = false; })
+
 let htmx: typeof import("htmx.org").default;
 async function main() {
   const htmxModule = await import('htmx.org');

--- a/src/scripts/main.ts
+++ b/src/scripts/main.ts
@@ -23,6 +23,18 @@ let restoringHistory = false;
 document.body.addEventListener(`htmx:historyCacheHit`, () => { restoringHistory = true; })
 document.body.addEventListener(`htmx:historyRestore`, () => { restoringHistory = false; })
 
+// htmx's history snapshot is built from elt.cloneNode(true), which captures the HTML
+// `value` attribute an input started with, not the live `.value` property that typing
+// (or our search-as-you-type handler) updates. That leaves inputs showing stale text
+// after a history cache-hit restore even though the rest of the page is current. Since
+// htmx:beforeHistorySave fires immediately before it clones the DOM for the snapshot,
+// syncing the attribute here is enough for the clone to pick up what's actually on screen.
+document.body.addEventListener(`htmx:beforeHistorySave`, () => {
+  document.body.querySelectorAll(`input[type="search"], input[type="text"]`).forEach((el) => {
+    el.setAttribute(`value`, (el as HTMLInputElement).value);
+  });
+})
+
 let htmx: typeof import("htmx.org").default;
 async function main() {
   const htmxModule = await import('htmx.org');

--- a/src/scripts/main.ts
+++ b/src/scripts/main.ts
@@ -1,8 +1,21 @@
 export * from "./components/dual-handle-slider"
 export * from "./components/closable-dialog"
 
-import { SwapOptions } from "htmx.org";
+import htmx, { SwapOptions } from "htmx.org";
 import "./main.css"
+
+// htmx's own popstate/history setup only runs once document.readyState reaches
+// 'complete', or else on the next 'DOMContentLoaded' - and that event fires at most
+// once per page. Loading htmx via a dynamic import() raced that: if the import
+// happened to resolve after DOMContentLoaded had already fired but before 'complete'
+// (readyState 'interactive' - e.g. blocked on the Google Fonts preconnects/stylesheet
+// below), htmx would register for an event that will never fire again, silently never
+// installing window.onpopstate for the rest of the page's life. Back/forward would
+// then update the URL bar (a native browser action) while doing nothing else, since
+// nothing was listening. A static import is fully resolved as part of module graph
+// evaluation, which itself is guaranteed to finish before DOMContentLoaded - closing
+// the race instead of trying to win it.
+(window as any).htmx = htmx;
 
 // Restoring a page from htmx's history cache (back/forward) replaces document.body's
 // innerHTML wholesale with the cached snapshot, then reprocesses it. Every element in
@@ -35,13 +48,7 @@ document.body.addEventListener(`htmx:beforeHistorySave`, () => {
   });
 })
 
-let htmx: typeof import("htmx.org").default;
 async function main() {
-  const htmxModule = await import('htmx.org');
-  htmx = htmxModule.default;
-
-  (window as any).htmx = htmx;
-  
   await import("htmx-ext-response-targets")
   await import("htmx-ext-sse")
   

--- a/src/scripts/main.ts
+++ b/src/scripts/main.ts
@@ -75,24 +75,6 @@ async function main() {
     },
   })
 
-  htmx.defineExtension(`interpolate-current-path`, {
-    onEvent(name, event) {
-      if(name === `htmx:configRequest`) {
-
-        
-        // Path that a request is sent to
-        const path = event.detail.path.split("?")[0]
-        // Query parameters sent to that path
-        const params = event.detail.path.split("?")[1] || ""
-
-        event.detail.path = `${path.replaceAll(`*`, window.location.pathname.slice(1))}?${params}`
-
-
-      }
-      return true
-    },
-  })
-
   // HTMX uses history.pushState, which does not update CSS :target pseudoclass: https://developer.mozilla.org/en-US/docs/Web/CSS/:target#description
   // Fix taken and modified from https://github.com/bigskysoftware/htmx/issues/3447
   htmx.on(`htmx:afterSwap`, (event: Event & { detail: SwapOptions["eventInfo"] }) => {

--- a/src/tests/test_pagination.py
+++ b/src/tests/test_pagination.py
@@ -1,0 +1,35 @@
+from src.utils.pagination import paginate_window
+
+
+def test_empty():
+    assert paginate_window(current=0, total=0) == []
+
+
+def test_single_page():
+    assert paginate_window(current=0, total=1) == [0]
+
+
+def test_small_total_shows_everything_no_ellipsis():
+    assert paginate_window(current=2, total=5) == [0, 1, 2, 3, 4]
+
+
+def test_large_total_at_start_collapses_tail():
+    assert paginate_window(current=0, total=171) == [0, 1, 2, None, 170]
+
+
+def test_large_total_in_middle_collapses_both_sides():
+    assert paginate_window(current=85, total=171) == [0, None, 83, 84, 85, 86, 87, None, 170]
+
+
+def test_large_total_at_end_collapses_head():
+    assert paginate_window(current=170, total=171) == [0, None, 168, 169, 170]
+
+
+def test_no_duplicate_or_single_gap_page():
+    # When the sibling window touches the first/last page exactly, there should be no
+    # dangling ellipsis hiding just a single page.
+    assert paginate_window(current=2, total=6) == [0, 1, 2, 3, 4, 5]
+
+
+def test_custom_sibling_count():
+    assert paginate_window(current=10, total=21, siblings=1) == [0, None, 9, 10, 11, None, 20]

--- a/src/utils/pagination.py
+++ b/src/utils/pagination.py
@@ -1,0 +1,21 @@
+def paginate_window(current: int, total: int, siblings: int = 2) -> list[int | None]:
+    """0-indexed page numbers to display around `current`, always including the first
+    and last page. `None` marks a gap between shown pages, meant to be rendered as an
+    ellipsis, so large page counts don't require rendering a button per page."""
+    if total <= 0:
+        return []
+
+    show = {0, total - 1, current}
+    for offset in range(1, siblings + 1):
+        show.add(current - offset)
+        show.add(current + offset)
+    ordered = sorted(p for p in show if 0 <= p < total)
+
+    result: list[int | None] = []
+    prev: int | None = None
+    for p in ordered:
+        if prev is not None and p - prev > 1:
+            result.append(None)
+        result.append(p)
+        prev = p
+    return result


### PR DESCRIPTION
## Summary

Fixes from a hands-on usability review of the live public instance, plus a follow-up download feature — details and verification steps in each commit.

- **Search/page lost on refresh**: `root.html`'s `<main>` fired its own `hx-get` on load but discarded the current filter/page query string, so any full page load (refresh, bookmark, shared link) silently reset back to page 1 unfiltered. Now forwards `request.query_string`.
- **Intermittent "Currently searching: \*"**: root-caused to htmx's ESM build running its own `DOMContentLoaded`-triggered auto-init independently of (and racing against) the app's own `htmx.process()` call — and `hx-trigger="load"` only ever fires once per element, so whichever pass won was permanent for that page load. Rather than trying to win the race, removed the custom `interpolate-current-path` extension dependency entirely: the dropdown now sends the current path via `hx-vals` (core htmx, no registration/race possible), with the backend reading it from a query param instead of a URL segment.
- **Uncaught JS error on every thumbnail**: guarded the `onload`/`onerror` handlers against a null `previousElementSibling` — it was throwing a real error per thumbnail and leaving orphaned skeleton `<div>`s behind.
- **171-button pagination strip**: replaced with a windowed view (first, last, current ±2, `…` for gaps) via a new `paginate_window()` utility with unit tests.
- **No way to save a generated clip**: added a download button over the clip preview. Needed `hx-boost="false"` on the link, since `<body hx-boost="true">` intercepts every same-origin anchor click into an AJAX fetch+swap with no exception for `download` links — without it, clicking the button dumped the raw binary clip into the page as text instead of downloading.

## Test plan

- [x] Full test suite passes (26 tests, including 8 new ones for `paginate_window`)
- [x] Verified filter/page persistence via direct navigation to `/?filter=...` and `/?page=N` — both now land on the correct page instead of resetting
- [x] Verified the dropdown fix via the actual rendered route/template output (no longer depends on client-side extension timing at all)
- [x] Verified pagination windowing against a synthetic 10-page dataset (start/middle/end cases)
- [x] Verified the download button live in a browser: clicked it end-to-end, confirmed no page navigation and no corrupted DOM content (the original bug this session), confirmed the served file is a valid clip

🤖 Generated with [Claude Code](https://claude.com/claude-code)